### PR TITLE
Add loop mode (`-L`) in the CLI SAPI

### DIFF
--- a/sapi/cli/config.m4
+++ b/sapi/cli/config.m4
@@ -28,7 +28,7 @@ if test "$PHP_CLI" != "no"; then
   SAPI_CLI_PATH=sapi/cli/php
 
   dnl Select SAPI
-  PHP_SELECT_SAPI(cli, program, php_cli.c php_http_parser.c php_cli_server.c ps_title.c php_cli_process_title.c, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1, '$(SAPI_CLI_PATH)')
+  PHP_SELECT_SAPI(cli, program, php_cli.c php_http_parser.c php_cli_server.c php_cli_loop.c ps_title.c php_cli_process_title.c, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1, '$(SAPI_CLI_PATH)')
 
   case $host_alias in
   *aix*)

--- a/sapi/cli/config.w32
+++ b/sapi/cli/config.w32
@@ -5,7 +5,7 @@ ARG_ENABLE('crt-debug', 'Enable CRT memory dumps for debugging sent to STDERR', 
 ARG_ENABLE('cli-win32', 'Build console-less CLI version of PHP', 'no');
 
 if (PHP_CLI == "yes") {
-	SAPI('cli', 'php_cli.c php_http_parser.c php_cli_server.c php_cli_process_title.c ps_title.c', 'php.exe', '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
+	SAPI('cli', 'php_cli.c php_http_parser.c php_cli_server.c php_cli_loop.c php_cli_process_title.c ps_title.c', 'php.exe', '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
 	ADD_FLAG("LIBS_CLI", "ws2_32.lib");
 	ADD_FLAG("LIBS_CLI", "shell32.lib");
 	if (PHP_CRT_DEBUG == "yes") {

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -84,6 +84,7 @@
 #ifndef PHP_CLI_WIN32_NO_CONSOLE
 #include "php_cli_server.h"
 #endif
+#include "php_cli_loop.h"
 
 #include "ps_title.h"
 #include "php_cli_process_title.h"
@@ -154,6 +155,7 @@ const opt_struct OPTIONS[] = {
 	{'h', 0, "help"},
 	{'i', 0, "info"},
 	{'l', 0, "syntax-check"},
+	{'L', 0, "loop"},
 	{'m', 0, "modules"},
 	{'n', 0, "no-php-ini"},
 	{'q', 0, "no-header"}, /* for compatibility with CGI (do not generate HTTP headers) */
@@ -521,6 +523,7 @@ static void php_cli_usage(char *argv0)
 				"  -h               This help\n"
 				"  -i               PHP information\n"
 				"  -l               Syntax check only (lint)\n"
+				"  -L               Loop mode\n"
 				"  -m               Show compiled in modules\n"
 				"  -r <code>        Run PHP <code> without using script tags <?..?>\n"
 				"  -B <begin_code>  Run PHP <begin_code> before processing input lines\n"
@@ -1323,6 +1326,9 @@ int main(int argc, char *argv[])
 			case 'e': /* enable extended info output */
 				use_extended_info = 1;
 				break;
+			case 'L':
+				sapi_module = &cli_loop_sapi_module;
+				break;
 		}
 	}
 exit_loop:
@@ -1388,8 +1394,10 @@ exit_loop:
 #endif
 			exit_status = do_cli(argc, argv);
 #ifndef PHP_CLI_WIN32_NO_CONSOLE
-		} else {
+		} else if (sapi_module == &cli_server_sapi_module) {
 			exit_status = do_cli_server(argc, argv);
+		} else {
+			exit_status = do_cli_loop(argc, argv);
 		}
 #endif
 	} zend_end_try();

--- a/sapi/cli/php_cli_loop.c
+++ b/sapi/cli/php_cli_loop.c
@@ -1,0 +1,323 @@
+/*
+   +----------------------------------------------------------------------+
+   | PHP Version 7                                                        |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1997-2018 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Author: Matthieu Napoli <matthieu@mnapoli.fr>                        |
+   +----------------------------------------------------------------------+
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <assert.h>
+
+#ifdef PHP_WIN32
+# include <process.h>
+# include <io.h>
+# include "win32/time.h"
+# include "win32/signal.h"
+# include "win32/php_registry.h"
+# include <sys/timeb.h>
+#else
+# include "php_config.h"
+#endif
+
+#ifdef __riscos__
+#include <unixlib/local.h>
+#endif
+
+#if HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+#if HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#if HAVE_SIGNAL_H
+#include <signal.h>
+#endif
+#if HAVE_SETLOCALE
+#include <locale.h>
+#endif
+#if HAVE_DLFCN_H
+#include <dlfcn.h>
+#endif
+
+#include "SAPI.h"
+#include "php.h"
+#include "php_ini.h"
+#include "php_main.h"
+#include "php_globals.h"
+#include "php_variables.h"
+#include "zend_hash.h"
+#include "zend_modules.h"
+#include "fopen_wrappers.h"
+#include "cli.h"
+
+#include "zend_compile.h"
+#include "zend_execute.h"
+#include "zend_highlight.h"
+#include "zend_exceptions.h"
+
+#include "php_getopt.h"
+
+#ifndef PHP_WIN32
+# define php_select(m, r, w, e, t)	select(m, r, w, e, t)
+# define SOCK_EINVAL EINVAL
+# define SOCK_EAGAIN EAGAIN
+# define SOCK_EINTR EINTR
+# define SOCK_EADDRINUSE EADDRINUSE
+#else
+# include "win32/select.h"
+# define SOCK_EINVAL WSAEINVAL
+# define SOCK_EAGAIN WSAEWOULDBLOCK
+# define SOCK_EINTR WSAEINTR
+# define SOCK_EADDRINUSE WSAEADDRINUSE
+#endif
+
+#include "ext/standard/file.h" /* for php_set_sock_blocking() :-( */
+#include "zend_smart_str.h"
+#include "ext/standard/html.h"
+#include "ext/standard/url.h" /* for php_raw_url_decode() */
+#include "ext/standard/php_string.h" /* for php_dirname() */
+#include "ext/date/php_date.h" /* for php_format_date() */
+
+#include "php_cli_loop.h"
+
+ZEND_DECLARE_MODULE_GLOBALS(cli_loop);
+
+PHP_INI_BEGIN()
+    // No ini settings to define
+PHP_INI_END()
+
+static PHP_MINIT_FUNCTION(cli_loop)
+{
+    REGISTER_INI_ENTRIES();
+    return SUCCESS;
+}
+
+static PHP_MSHUTDOWN_FUNCTION(cli_loop)
+{
+    UNREGISTER_INI_ENTRIES();
+    return SUCCESS;
+}
+
+static PHP_MINFO_FUNCTION(cli_loop)
+{
+    DISPLAY_INI_ENTRIES();
+}
+
+zend_module_entry cli_loop_module_entry = {
+    STANDARD_MODULE_HEADER,
+    "cli_loop",
+    NULL,
+    PHP_MINIT(cli_loop),
+    PHP_MSHUTDOWN(cli_loop),
+    NULL,
+    NULL,
+    PHP_MINFO(cli_loop),
+    PHP_VERSION,
+    STANDARD_MODULE_PROPERTIES
+};
+/* }}} */
+
+static int sapi_cli_loop_startup(sapi_module_struct *sapi_module) /* {{{ */
+{
+    if (php_module_startup(sapi_module, &cli_loop_module_entry, 1) == FAILURE) {
+        return FAILURE;
+    }
+    return SUCCESS;
+} /* }}} */
+
+static size_t sapi_cli_loop_ub_write(const char *str, size_t str_length) /* {{{ */
+{
+    const char *ptr = str;
+    size_t remaining = str_length;
+    ssize_t ret;
+
+    if (!str_length) {
+        return 0;
+    }
+
+    while (remaining > 0)
+    {
+        ret = sapi_cli_single_write(ptr, remaining);
+        if (ret < 0) {
+#ifndef PHP_CLI_WIN32_NO_CONSOLE
+            EG(exit_status) = 255;
+            php_handle_aborted_connection();
+#endif
+            break;
+        }
+        ptr += ret;
+        remaining -= ret;
+    }
+
+    return (ptr - str);
+}
+/* }}} */
+
+static void sapi_cli_loop_flush(void *server_context) /* {{{ */
+{
+    /* Ignore EBADF here, it's caused by the fact that STDIN/STDOUT/STDERR streams
+     * are/could be closed before fflush() is called.
+     */
+    if (fflush(stdout)==EOF && errno!=EBADF) {
+#ifndef PHP_CLI_WIN32_NO_CONSOLE
+        php_handle_aborted_connection();
+#endif
+    }
+}
+/* }}} */
+
+static int sapi_cli_loop_send_headers(sapi_headers_struct *sapi_headers) /* {{{ */
+{
+    /* We do nothing here, this function is needed to prevent that the fallback
+     * header handling is called. */
+    return SAPI_HEADER_SENT_SUCCESSFULLY;
+}
+/* }}} */
+
+static void sapi_cli_loop_log_message(char *msg, int syslog_type_int) /* {{{ */
+{
+    // Log to stderr
+    fprintf(stderr, "%s\n", msg);
+} /* }}} */
+
+/* {{{ sapi_module_struct cli_loop_sapi_module
+ */
+sapi_module_struct cli_loop_sapi_module = {
+		"cli-loop",						/* name */
+		"Loop runner",					/* pretty name */
+
+		sapi_cli_loop_startup,			/* startup */
+		php_module_shutdown_wrapper,	/* shutdown */
+
+		NULL,							/* activate */
+		NULL,							/* deactivate */
+
+        sapi_cli_loop_ub_write,		    /* unbuffered write */
+        sapi_cli_loop_flush,			/* flush */
+		NULL,							/* get uid */
+		NULL,							/* getenv */
+
+		php_error,						/* error handler */
+
+		NULL,							/* header handler */
+        sapi_cli_loop_send_headers,		/* send headers handler */
+		NULL,							/* send header handler */
+
+		NULL,							/* read POST data */
+		NULL,							/* read Cookies */
+
+		NULL,							/* register server variables */
+		sapi_cli_loop_log_message,		/* Log message */
+		NULL,							/* Get request time */
+		NULL,							/* Child terminate */
+
+		STANDARD_SAPI_MODULE_PROPERTIES
+}; /* }}} */
+
+static int php_cli_loop_run_script(const char *filename) /* {{{ */
+{
+	int stop = 0;
+	zend_file_handle zfd;
+	char *old_cwd;
+
+	ALLOCA_FLAG(use_heap)
+	old_cwd = do_alloca(MAXPATHLEN, use_heap);
+	old_cwd[0] = '\0';
+	php_ignore_value(VCWD_GETCWD(old_cwd, MAXPATHLEN - 1));
+
+	zfd.type = ZEND_HANDLE_FILENAME;
+	zfd.filename = filename;
+	zfd.handle.fp = NULL;
+	zfd.free_filename = 0;
+	zfd.opened_path = NULL;
+
+	zend_try {
+			zval retval;
+
+			ZVAL_UNDEF(&retval);
+			if (SUCCESS == zend_execute_scripts(ZEND_REQUIRE, &retval, 1, &zfd)) {
+				if (Z_TYPE(retval) != IS_UNDEF) {
+					// If it's `false` then stop
+					stop = Z_TYPE(retval) == IS_FALSE;
+					zval_ptr_dtor(&retval);
+				}
+			} else {
+				stop = 0;
+			}
+	} zend_end_try();
+
+	if (old_cwd[0] != '\0') {
+		php_ignore_value(VCWD_CHDIR(old_cwd));
+	}
+
+	free_alloca(old_cwd, use_heap);
+
+	return stop;
+}
+/* }}} */
+
+static bool php_cli_loop_is_running = true;
+
+static void php_cli_loop_sigint_handler(int sig) /* {{{ */
+{
+	php_cli_loop_is_running = 0;
+}
+/* }}} */
+
+int do_cli_loop(int argc, char **argv) /* {{{ */
+{
+    int stop = 0;
+	const char *script_name = NULL;
+
+	if (argc > 2) {
+		script_name = argv[2];
+	} else {
+        php_printf("You must provide a script to execute\n");
+		return 1;
+	}
+
+#if defined(HAVE_SIGNAL_H) && defined(SIGINT)
+	signal(SIGINT, php_cli_loop_sigint_handler);
+	zend_signal_init();
+#endif
+
+	while (php_cli_loop_is_running) {
+		// Startup PHP
+		if (FAILURE == php_request_startup()) {
+			/* should never be happen */
+			return FAILURE;
+		}
+
+        stop = php_cli_loop_run_script(script_name);
+
+        php_request_shutdown(0);
+
+		if (stop) {
+			return FAILURE;
+		}
+	}
+
+	return 0;
+} /* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/sapi/cli/php_cli_loop.h
+++ b/sapi/cli/php_cli_loop.h
@@ -1,0 +1,47 @@
+/*
+   +----------------------------------------------------------------------+
+   | PHP Version 7                                                        |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 1997-2018 The PHP Group                                |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.php.net/license/3_01.txt                                  |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Author: Matthieu Napoli <matthieu@mnapoli.fr>                        |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef PHP_CLI_LOOP_H
+#define PHP_CLI_LOOP_H
+
+#include "SAPI.h"
+
+extern sapi_module_struct cli_loop_sapi_module;
+extern int do_cli_loop(int argc, char **argv);
+
+ZEND_BEGIN_MODULE_GLOBALS(cli_loop)
+    // none
+ZEND_END_MODULE_GLOBALS(cli_loop)
+
+#ifdef ZTS
+#define CLI_LOOP_G(v) ZEND_TSRMG(cli_loop_globals_id, zend_cli_loop_globals *, v)
+ZEND_TSRMLS_CACHE_EXTERN()
+#else
+#define CLI_LOOP_G(v) (cli_loop_globals.v)
+#endif
+
+#endif /* PHP_CLI_LOOP_H */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */


### PR DESCRIPTION
This is a pull request that I opened in my own fork to preview the diff and allow code review.

This PR adds a new "Loop" mode that can be used with `-L`. For example: `php -L script.php`.

This mode runs the script in a loop.

The big difference with doing a `while(true) {}` loop in PHP is that **every execution of the script is isolated from the other executions.**

### Use cases

- **Workers**, i.e. processing jobs in a message queue: instead of running in a loop the script can process one job, the "Loop" mode will ensure the script will loop => each job will be processed in a fresh PHP environment, meaning no memory leaks, no shared state, etc.
- **AWS Lambda**: by running `php -L` each event/request would be processed in an isolated PHP environment without having the overhead of starting a new process (*this is the main reason that motivated this work, I will publish more information about this soon*)

Maybe there are opportunities too for ReactPHP/Amp/Aerys/etc to benefit from that (provide very fast response times without having to sacrifice request isolation).

### Example

Before:

```php
<?php
// script.php
$a = 'foo';
while (true) {
    echo $a . PHP_EOL;
    $a = 'bar';
}
```

```shell
$ php -L script.php
foo
bar
bar
[...]
```
With the "loop mode":

```php
<?php
// script.php
$a = 'foo';
echo $a . PHP_EOL;
$a = 'bar';
```

```shell
$ php -L script.php
foo
foo
foo
[...]
```